### PR TITLE
Add created_by field to Tool entity and form submission

### DIFF
--- a/src/main/java/com/example/p3/entities/Tool.java
+++ b/src/main/java/com/example/p3/entities/Tool.java
@@ -82,7 +82,7 @@ public class Tool {
     )
     private Set<Tag> tags = new HashSet<>();
 
-    public Tool(Integer id, String name, String url, Boolean is_personal, Boolean is_dynamic, Set<Department> departments, Set<Jurisdiction> jurisdictions, Set<Stage> stages, Set<Tag> tags, Boolean pending) {
+    public Tool(Integer id, String name, String url, Boolean is_personal, Boolean is_dynamic, Set<Department> departments, Set<Jurisdiction> jurisdictions, Set<Stage> stages, Set<Tag> tags, Boolean pending, Employee created_by) {
         this.id = id;
         this.name = name;
         this.url = url;
@@ -93,6 +93,7 @@ public class Tool {
         this.stages = stages;
         this.tags = tags;
         this.pending = pending;
+        this.created_by = created_by;
     }
 
     public Tool() {}

--- a/src/main/resources/static/js/submitForm.js
+++ b/src/main/resources/static/js/submitForm.js
@@ -78,6 +78,9 @@ export async function formToJSON(){
     //Added to the pending tool list
     const pending = !isPersonal;
 
+    //created by
+    const createdBy = await getCurrentEmployee();
+
     //Validation checks
 
     if (name.trim() === ""){ throw new Error("Tool name cannot be empty"); }
@@ -91,7 +94,7 @@ export async function formToJSON(){
     if (jurisdictions.length === 0){throw new Error("At least one jurisdiction must be selected.");}
 
 
-    return JSON.stringify({is_personal : isPersonal , name, url, is_dynamic : isDynamic, departments, stages, jurisdictions, tags, pending});
+    return JSON.stringify({is_personal : isPersonal , name, url, is_dynamic : isDynamic, departments, stages, jurisdictions, tags, pending, created_by: createdBy});
 }
 
 //Gets the url value regarding if it is dynamic


### PR DESCRIPTION
Updated the Tool constructor to accept a created_by Employee and set the field. Modified formToJSON in submitForm.js to include the created_by property using the current employee. This change ensures that the creator of a Tool is tracked during creation.